### PR TITLE
Dispatch in various files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,10 +3,10 @@
 *.png
 *.csv
 *.txt
-*.ipynb
 .DS_Store
 
 .idea/
 */__pycache__/
 results/*
 data/*
+.ipynb_checkpoints/

--- a/recency_model.ipynb
+++ b/recency_model.ipynb
@@ -1,0 +1,194 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 102,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The autoreload extension is already loaded. To reload it, use:\n",
+      "  %reload_ext autoreload\n"
+     ]
+    }
+   ],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import math\n",
+    "import numpy\n",
+    "import pandas as pd\n",
+    "import time\n",
+    "\n",
+    "\n",
+    "import src.tools as tools\n",
+    "import src.recencytools as recency\n",
+    "import src.postprocess as postprocess\n",
+    "import src.preprocess as preprocess\n",
+    "import src.tfidftools as tfidftools\n",
+    "\n",
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 90,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "path_to_data = 'data/'\n",
+    "\n",
+    "training = pd.read_csv(path_to_data + 'training_set.csv', sep=',', header=0)\n",
+    "\n",
+    "training_info = pd.read_csv(\n",
+    "    path_to_data + 'training_info.csv', sep=',', parse_dates=True, header=0)\n",
+    "\n",
+    "test = pd.read_csv(path_to_data + 'test_set.csv', sep=',', header=0)\n",
+    "\n",
+    "path_to_results = 'results/'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Beta is the coefficient that regulates time discrepancy.\n",
+    "The higher beta is, the more importance is given to older messages.\n",
+    "\n",
+    "Each mail is weighted according to its rank (order of anciency)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 91,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "beta = 100\n",
+    "training_info = recency.add_time_rank_to_dataframe(training_info) # Run only once !\n",
+    "email_ranks_dic = recency.get_email_ranks(training_info)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 93,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "9.92548388600989e-60"
+      ]
+     },
+     "execution_count": 93,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Compute score for a given mid\n",
+    "some_mid = 378257\n",
+    "recency.get_email_recency_score(email_ranks_dic, some_mid, beta)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Compute the recency address book."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 94,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "processed 0 senders\n",
+      "processed 10 senders\n",
+      "processed 20 senders\n",
+      "processed 30 senders\n",
+      "processed 40 senders\n",
+      "processed 50 senders\n",
+      "processed 60 senders\n",
+      "processed 70 senders\n",
+      "processed 80 senders\n",
+      "processed 90 senders\n",
+      "processed 100 senders\n",
+      "processed 110 senders\n",
+      "processed 120 senders\n"
+     ]
+    }
+   ],
+   "source": [
+    "email_ids_per_sender = get_email_ids_per_sender(training)\n",
+    "recency_address_books = recency.get_recency_address_books(email_ids_per_sender, training_info, beta)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 82,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Write recency predictions to file\n",
+    "postprocess.write_prediction_from_addressbook(test, recency_address_books,\n",
+    "                                              path_to_results, 'predictions_recency_{beta}.txt'.format(beta=beta))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.4.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/src/graphtools.py
+++ b/src/graphtools.py
@@ -1,0 +1,14 @@
+# Some graph utilities
+def build_graph(address_book):
+    adj_by_sender = {}
+    for sender, val in address_book.items():
+        adj_by_sender[sender] = pd.Series([el[1] for el in val], index=[
+                                          el[0] for el in val], name=sender)
+    adjacency_mat = pd.DataFrame.from_dict(adj_by_sender).T.fillna(0)
+    adjacency_mat = adjacency_mat.T.dot(adjacency_mat)
+    return adjacency_mat
+
+
+def get_neighbors(sender, adjacency_matrix):
+    return adjacency_matrix.loc[sender].nonzero()[0]
+

--- a/src/postprocess.py
+++ b/src/postprocess.py
@@ -1,0 +1,43 @@
+def write_results(results, path_to_results, results_name):
+    """
+    Writes results to csv file for kaggle submission
+    result must be a dict {mid:[(prob1, sender1), ...]}
+    """
+    with open(path_to_results + results_name, 'wb') as f:
+        f.write(bytes('mid,recipients\n', 'UTF-8'))
+        for mid, preds in results.items():
+            preds_no_prob = [x[1] for x in preds]
+            f.write(bytes(str(mid) + ',' +
+                          ' '.join(preds_no_prob) + '\n', 'UTF-8'))
+
+
+def write_prediction_from_addressbook(test_df, address_books, path_to_results,
+                                      result_name, k=10):
+    """
+    Writes results to csv file for kaggle submission
+    for text-independent models (frequency, recency)
+    address_books must be a dict with sender as key and recpient as value
+    with recipients ordered according to rank
+    """
+    predictions_per_sender = {}
+    for index, row in test_df.iterrows():
+        name_ids = row.tolist()
+        sender = name_ids[0]
+        # get IDs of the emails for which recipient prediction is needed
+        mids_predict = name_ids[1].split(' ')
+        mids_predict = [int(my_id) for my_id in mids_predict]
+        recency_preds = []
+        # select k most frequent recipients for the user
+        k_most = [elt[0] for elt in address_books[sender][:k]]
+        for id_predict in mids_predict:
+            # for recency baselines, the predictions are always the same
+            recency_preds.append(k_most)
+        predictions_per_sender[sender] = [mids_predict, recency_preds]
+    with open(path_to_results + result_name, 'wb') as my_file:
+        my_file.write(bytes('mid,recipients\n', 'UTF-8'))
+        for sender, preds in predictions_per_sender.items():
+            ids = preds[0]
+            freq_preds = preds[1]
+            for index, my_preds in enumerate(freq_preds):
+                my_file.write(bytes(str(ids[index]) + ',' +
+                                    ' '.join(my_preds) + '\n', 'UTF-8'))

--- a/src/preprocess.py
+++ b/src/preprocess.py
@@ -1,0 +1,43 @@
+def get_email_ids_per_sender(email_df):
+    """
+    returns dictionnary with email address as key and mid list as value
+    """
+    emails_ids_per_sender = {}
+    for index, series in email_df.iterrows():
+        row = series.tolist()
+        sender = row[0]
+        ids = row[1:][0].split(' ')
+        emails_ids_per_sender[sender] = ids
+    return emails_ids_per_sender
+
+
+def body_dict_from_panda(dataframe):
+    """
+    Constructs dictionnary of bodies from dataframe with mid as key
+    """
+    body_dict = {}
+    nb_total = len(dataframe)
+    print('Constructing dictionnary from dataframe...')
+    for id, row in dataframe.iterrows():
+        body_dict[row.mid] = row.body
+        if(id % 10000 == 0):
+            print('{id} / {nb_total}'.format(id=id, nb_total=nb_total))
+    print('done !')
+    return body_dict
+
+
+def get_all_senders(email_ids_per_sender):
+    """
+    Returns all unique sender names
+    """
+    return email_ids_per_sender.keys()
+
+
+def get_all_recipients(address_book):
+    """
+    @return all_recs a list of all recipients for the given address_book
+    with address_books with sender as key and recipients as ranked list
+    """
+    all_recs = list(
+        set([elt[0] for sublist in address_books.values() for elt in sublist]))
+    return all_recs

--- a/src/recencytools.py
+++ b/src/recencytools.py
@@ -1,0 +1,113 @@
+from collections import Counter, defaultdict
+import operator
+import math
+import pandas as pd
+
+
+def add_time_rank_to_dataframe(df):
+
+    # Set mails with absurd dates to date before any real mail
+    min_date_string = '1998-12-20 00:00:01'
+
+    correct_prefix = [chars[0:2] == '00' for chars in list(df['date'])]
+    df.loc[correct_prefix, 'date'] = min_date_string
+
+    # Convert dates to timestamps
+    df['date'] = pd.to_datetime(df['date'], yearfirst=True)
+
+    # Add time rank column and sort dataframe
+    df['time_rank'] = df['date'].rank(ascending=False)
+    df = df.sort_values('date')
+    return df
+
+
+def get_frequency_address_books(emails_ids_per_sender, email_df):
+    """
+    Create address book with frequency information for each user
+    @return address_books with sender as key and recipients as ranked list
+    """
+    address_books = {}
+    idx_sender = 0
+
+    for sender, ids in emails_ids_per_sender.items():
+        recs_temp = []
+        for my_id in ids:
+            recipients = email_df[email_df['mid'] == int(my_id)][
+                'recipients'].tolist()
+            recipients = recipients[0].split(' ')
+            # keep only legitimate email addresses
+            recipients = [rec for rec in recipients if '@' in rec]
+            recs_temp.append(recipients)
+        # flatten
+        recs_temp = [elt for sublist in recs_temp for elt in sublist]
+        # compute recipient counts
+        rec_occ = dict(Counter(recs_temp))
+        # order by frequency
+        sorted_rec_occ = sorted(
+            rec_occ.items(), key=operator.itemgetter(1), reverse=True)
+        # save
+        address_books[sender] = sorted_rec_occ
+
+        if idx_sender % 10 == 0:
+            print('processed {nb_sender} senders'.format(nb_sender=idx_sender))
+        idx_sender += 1
+    return address_books
+
+
+def get_recency_address_books(emails_ids_per_sender, email_df, beta):
+    """
+    Create address book with recency information for each user
+    @return address_books with sender as key and recipients as ranked list
+    """
+    address_books = {}
+    idx_sender = 0
+    email_ranks_dic = get_email_ranks(email_df)
+    for sender, ids in emails_ids_per_sender.items():
+        recipients_scores = defaultdict(lambda: 0)
+        for my_id in ids:
+            my_id = int(my_id)
+            recency_score = get_email_recency_score(
+                email_ranks_dic, my_id, beta)
+            recipients = email_df[email_df['mid'] == int(my_id)][
+                'recipients'].tolist()
+            recipients = recipients[0].split(' ')
+            # keep only legitimate email addresses
+            recipients = [rec for rec in recipients if '@' in rec]
+            for recipient in recipients:
+                recipients_scores[recipient] += recency_score
+        # flatten
+        rec_occ = dict(Counter(recipients_scores))
+        # order by frequency
+        sorted_rec_occ = sorted(
+            rec_occ.items(), key=operator.itemgetter(1), reverse=True)
+        # save
+        address_books[sender] = sorted_rec_occ
+
+        if idx_sender % 10 == 0:
+            print('processed {nb_sender} senders'.format(nb_sender=idx_sender))
+        idx_sender += 1
+    return address_books
+
+
+def get_email_ranks(email_df):
+    """
+    Creates dictionnary that links mid to time rank
+    (1 for most recent mail)
+    """
+    return dict(zip(email_df['mid'], email_df['time_rank']))
+
+
+def get_email_rank(mid_rank_dic, mid):
+    """
+    Retrieve email rank for given mid
+    """
+    return mid_rank_dic[mid]
+
+
+def get_email_recency_score(mid_rank_dic, mid, beta):
+    """
+    Compute the recency score for a given mid
+    """
+    mid_rank = get_email_rank(mid_rank_dic, mid)
+    recency_score = math.exp(- mid_rank / beta)
+    return recency_score

--- a/src/tfidftools.py
+++ b/src/tfidftools.py
@@ -1,0 +1,17 @@
+import nltk
+from sklearn.feature_extraction.text import TfidfVectorizer
+
+# TfIDF utilities
+
+
+def get_tokens(body):
+    """Tokenizes an email"""
+    body = nltk.word_tokenize(body)
+    body = [word.lower() for word in body]
+    return body
+
+
+def get_tfidf(token_dict, min_df=0.001, max_df=0.10):
+    tfidf = TfidfVectorizer(tokenizer=get_tokens, min_df=min_df, max_df=max_df)
+    tfs = tfidf.fit_transform(token_dict.values())
+    return tfidf

--- a/src/tfidfutils.py
+++ b/src/tfidfutils.py
@@ -1,0 +1,17 @@
+import nltk
+from sklearn.feature_extraction.text import TfidfVectorizer
+
+# TfIDF utilities
+
+
+def get_tokens(body):
+    """Tokenizes an email"""
+    body = nltk.word_tokenize(body)
+    body = [word.lower() for word in body]
+    return body
+
+
+def get_tfidf(token_dict, min_df=0.001, max_df=0.10):
+    tfidf = TfidfVectorizer(tokenizer=get_tokens, min_df=min_df, max_df=max_df)
+    tfs = tfidf.fit_transform(token_dict.values())
+    return tfidf

--- a/src/tools.py
+++ b/src/tools.py
@@ -1,7 +1,6 @@
 import json
-import nltk
 import numpy
-from sklearn.feature_extraction.text import TfidfVectorizer
+import pandas as pd
 import time
 
 
@@ -14,7 +13,7 @@ def timeit(f):
         te = time.time()
 
         print('func:{funcname} took: {time:.4f} sec'.format(
-              funcname=f.__name__, time=te-ts))
+              funcname=f.__name__, time=te - ts))
         return result
     return timed
 
@@ -29,42 +28,3 @@ def dict_from_file(file_path):
     with open(file_path) as infile:
         data = json.load(infile)
     return data
-
-
-def body_dict_from_panda(dataframe):
-    """Constructs dictionnary of bodies from dataframe with mid as key"""
-    body_dict = {}
-    nb_total = len(dataframe)
-    print('Constructing dictionnary from dataframe...')
-    for id, row in dataframe.iterrows():
-        if(id % 10000 == 0):
-            print('{id} / {nb_total}'.format(id=id, nb_total=nb_total))
-        body_dict[row.mid] = row.body
-    print('done !')
-    return body_dict
-
-
-def get_tokens(body):
-    """Tokenizes an email"""
-    body = nltk.word_tokenize(body)
-    body = [word.lower() for word in body]
-    return body
-
-
-@timeit
-def get_tfidf(token_dict, min_df=0.001, max_df=0.10):
-    tfidf = TfidfVectorizer(tokenizer=get_tokens, min_df=min_df, max_df=max_df)
-    tfs = tfidf.fit_transform(token_dict.values())
-    return tfidf
-
-  
-def write_results(results, path_to_results, results_name):
-    """
-    Writes results to csv file for kaggle submission
-    result must be a dict {mid:[(prob1, sender1), ...]}
-    """
-    with open(path_to_results + results_name, 'wb') as f:
-        f.write(bytes('mid,recipients\n', 'UTF-8'))
-        for mid, preds in results.items():
-            preds_no_prob = [x[1] for x in preds]
-            f.write(bytes(str(mid) + ',' + ' '.join(preds_no_prob) + '\n', 'UTF-8'))

--- a/tdidf_model.ipynb
+++ b/tdidf_model.ipynb
@@ -1,0 +1,165 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import numpy\n",
+    "import pandas as pd\n",
+    "import random\n",
+    "\n",
+    "import src.tools as tools\n",
+    "import src.recencytools as recency\n",
+    "import src.postprocess as postprocess\n",
+    "import src.preprocess as preprocess\n",
+    "import src.tfidftools as tfidftools\n",
+    "\n",
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "path_to_data = 'data/'\n",
+    "\n",
+    "training = pd.read_csv(path_to_data + 'training_set.csv', sep=',', header=0)\n",
+    "\n",
+    "training_info = pd.read_csv(\n",
+    "    path_to_data + 'training_info.csv', sep=',', parse_dates=True, header=0)\n",
+    "\n",
+    "test = pd.read_csv(path_to_data + 'test_set.csv', sep=',', header=0)\n",
+    "\n",
+    "path_to_results = 'results/'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Constructing dictionnary from dataframe...\n",
+      "0 / 43613\n",
+      "10000 / 43613\n",
+      "20000 / 43613\n",
+      "30000 / 43613\n",
+      "40000 / 43613\n",
+      "done !\n"
+     ]
+    }
+   ],
+   "source": [
+    "token_dict = preprocess.body_dict_from_panda(training_info)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "tfidf = tfidftools.get_tfidf(token_dict, 0.001, 0.10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "8924\n",
+      "  (0, 4052)\t0.767714628649\n",
+      "  (0, 2730)\t0.640791892082\n"
+     ]
+    }
+   ],
+   "source": [
+    "idfs = tfidf.idf_\n",
+    "print(len(idfs))\n",
+    "idfs.sort()\n",
+    "idfs\n",
+    "print(tfidf.transform(['this is a great day for us']))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'token_dict' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-4-452afa84a07d>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mtfidf\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mtfidftools\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget_tfidf\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtoken_dict\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m0.001\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m0.10\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m: name 'token_dict' is not defined"
+     ]
+    }
+   ],
+   "source": [
+    "#print(tfidf.vocabulary_)\n",
+    "len(tfidf.idf_)\n",
+    "plt.plot(idfs)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "tfidf.transform()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.4.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Moved files around 

-  *tfidftools.py* contains the tfidf utility functions are now in this file @btaille you will have to relink those functions to your code from their new files :)

- *postprocessing.py* utilities to write the predictions to kaggle csv should go into 

- *preprocessing.py* : generic functions for data frames go and other dat-relevant dics

- *graphtools.py*: contains @GeoffNN 's initial graph functions 

- *tools.py* : generic functions (saving and reading objects from files and timing utility)

I have also remove the .ipynb from gitignore as we work mainly in notebooks it is interesting to be able to look at what the others are doing. Try to name those notebooks explicitely :)